### PR TITLE
Added support for using semicolons instead of end

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -3999,28 +3999,6 @@
     return target;
   }
 
-  // Utility for getTokenAt and getLineTokens
-  function takeToken(cm, pos, precise, asArray) {
-    function getObj(copy) {
-      return {start: stream.start, end: stream.pos,
-        string: stream.current(),
-        type: style || null,
-        state: copy ? copyState(doc.mode, state) : state};
-    }
-
-    var doc = cm.doc, mode = doc.mode, style;
-    pos = clipPos(doc, pos);
-    var line = getLine(doc, pos.line), state = getStateBefore(cm, pos.line, precise);
-    var stream = new StringStream(line.text, cm.options.tabSize), tokens;
-    if (asArray) tokens = [];
-    while ((asArray || stream.pos < pos.ch) && !stream.eol()) {
-      stream.start = stream.pos;
-      style = readToken(mode, stream, state);
-      if (asArray) tokens.push(getObj(true));
-    }
-    return asArray ? tokens : getObj();
-  }
-
   // EDITOR METHODS
 
   // The publicly visible API. Note that methodOp(f) means
@@ -4109,11 +4087,20 @@
     // Fetch the parser token for a given character. Useful for hacks
     // that want to inspect the mode state (say, for completion).
     getTokenAt: function(pos, precise) {
-      return takeToken(this, pos, precise);
-    },
-
-    getLineTokens: function(line, precise) {
-      return takeToken(this, Pos(line), precise, true);
+      var doc = this.doc;
+      pos = clipPos(doc, pos);
+      var state = getStateBefore(this, pos.line, precise), mode = this.doc.mode;
+      var line = getLine(doc, pos.line);
+      var stream = new StringStream(line.text, this.options.tabSize);
+      while (stream.pos < pos.ch && !stream.eol()) {
+        stream.start = stream.pos;
+        var style = readToken(mode, stream, state);
+      }
+      return {start: stream.start,
+              end: stream.pos,
+              string: stream.current(),
+              type: style || null,
+              state: state};
     },
 
     getTokenTypeAt: function(pos) {

--- a/mode/pyret/pyret.js
+++ b/mode/pyret/pyret.js
@@ -3,15 +3,25 @@ CodeMirror.defineMode("pyret", function(config, parserConfig) {
   function wordRegexp(words) {
     return new RegExp("^((" + words.join(")|(") + "))(?![a-zA-Z0-9-_])");
   }
+  function toToken(type) {
+    return function(tstr) {
+      return {type: type, string: tstr};
+    };
+  }
   
   const pyret_indent_regex = new RegExp("^[a-zA-Z_][a-zA-Z0-9$_\\-]*");
   const pyret_closing_keywords = ["end"];
+  const pyret_closing_builtins = [";"];
+  const pyret_closing_tokens =
+        pyret_closing_keywords.map(toToken("keyword")).concat(
+          pyret_closing_builtins.map(toToken("builtin")));
   const pyret_opening_keywords_colon = ["try", "ask", "ref-graph", "block"];
   const pyret_opening_keywords_nocolon = ["fun", "when", "for", "if", "let",
                                           "cases", "data", "shared", "check",
                                           "except", "letrec", "lam", "method",
                                           "examples"];
   const pyret_opening_keywords = pyret_opening_keywords_colon.concat(pyret_opening_keywords_nocolon);
+  const pyret_opening_tokens = pyret_opening_keywords.map(toToken("keyword"));
   const pyret_keywords = 
     wordRegexp(["else if"].concat(pyret_opening_keywords_nocolon, pyret_closing_keywords,
                ["var", "rec", "import", "include", "provide", "type", "newtype",
@@ -708,7 +718,7 @@ CodeMirror.defineMode("pyret", function(config, parserConfig) {
 
     fold: "pyret",
 
-    delimiters: {opening: pyret_opening_keywords, closing: pyret_closing_keywords}
+    delimiters: {opening: pyret_opening_tokens, closing: pyret_closing_tokens}
 
   };
   return external;


### PR DESCRIPTION
@blerner @jpolitz 

I also tried to increase future flexibility for such additions. I went ahead and set things up to export the token types in the Pyret mode, but that is mainly in case they are needed for some later feature. The increase in overhead caused by this should be minimal, since the 'throwing away' of those fields is done once when the file is loaded. Also, they provide a small amount of sanity checking for what the Pyret mode is giving us :)
